### PR TITLE
fix: align package entry paths with emitted bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.2.0",
   "description": "VitePress plugin that renders Vue components with tabs showing preview and source code",
   "type": "module",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/index.mjs",
+  "module": "dist/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",


### PR DESCRIPTION
## Summary

The published `vitepress-plugin-component@1.2.0` package contains `dist/index.mjs` and `dist/index.d.mts`, and its package exports already point the default entry to `./dist/index.mjs`.

However, the legacy `main` and `module` fields still point to `dist/index.js`, which is not emitted by the current `tsdown` build and is not present in the npm tarball. This PR aligns those fields with the actual ESM output.

## Validation

- `npm pack vitepress-plugin-component@1.2.0 --dry-run --json` confirms `dist/index.mjs` is present and `dist/index.js` is absent in the published package.
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm build`
- `npm pack --dry-run --json` confirms the package includes `dist/index.mjs` and `dist/index.d.mts`.
- `node -e "const p=require('./package.json'); if (p.main !== 'dist/index.mjs' || p.module !== 'dist/index.mjs') throw new Error(JSON.stringify({main:p.main,module:p.module})); console.log(JSON.stringify({main:p.main,module:p.module, exportDefault:p.exports['.'].default, types:p.types}))"`
- `git diff --check`