### PR TITLE
fix: add missing bugs metadata field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "vitepress-plugin-component",
   "version": "1.2.0",
+  "bugs": {
+    "url": "https://github.com/heroui-vue/vitepress-plugin-component/issues"
+  },
   "description": "VitePress plugin that renders Vue components with tabs showing preview and source code",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Adds missing package metadata fields to `package.json`.

This allows npm tooling and consumers to correctly resolve package metadata.